### PR TITLE
Add website column to EstablishmentTable component

### DIFF
--- a/components/EstablishmentTable.tsx
+++ b/components/EstablishmentTable.tsx
@@ -33,6 +33,9 @@ export default function EstablishmentTable({ establishments }: EstablishmentTabl
               Horário
             </th>
             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Site
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Ações
             </th>
           </tr>
@@ -79,6 +82,21 @@ export default function EstablishmentTable({ establishments }: EstablishmentTabl
                 <div className="text-sm text-gray-600 max-w-xs truncate" title={establishment.hours}>
                   {establishment.hours}
                 </div>
+              </td>
+              <td className="px-6 py-4 whitespace-nowrap">
+                {establishment.website ? (
+                  <a 
+                    href={establishment.website} 
+                    target="_blank" 
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:text-blue-800 text-sm truncate max-w-32 inline-block"
+                    title={establishment.website}
+                  >
+                    🌐 Ver site
+                  </a>
+                ) : (
+                  <span className="text-gray-400 text-sm">-</span>
+                )}
               </td>
               <td className="px-6 py-4 whitespace-nowrap">
                 <div className="flex space-x-2">


### PR DESCRIPTION
## Summary
- Adds a new "Site" column to the EstablishmentTable component
- Displays the establishment's website as a clickable link if available
- Shows a placeholder dash if no website is provided

## Changes

### UI Components
- **EstablishmentTable.tsx**:
  - Added a new table header for "Site"
  - Rendered the website link with proper styling and accessibility attributes
  - Included a fallback display when the website is not available

## Test plan
- [x] Verify the new "Site" column appears in the table header
- [x] Confirm website links open in a new tab with correct attributes
- [x] Check that establishments without a website show a dash placeholder
- [x] Ensure the link text is truncated and styled appropriately

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/df31e9b1-7904-4ee5-8fa4-2c2b90729191