### PR TITLE
Fix button size in EstablishmentCards component

### DIFF
--- a/components/EstablishmentCards.tsx
+++ b/components/EstablishmentCards.tsx
@@ -58,13 +58,13 @@ export default function EstablishmentCards({ establishments }: EstablishmentCard
 
             <div className="flex gap-2 pt-4">
               {establishment.phone && (
-                <button className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
+                <button className="px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50">
                   📞 Ligar
                 </button>
               )}
               {establishment.website && (
                 <button 
-                  className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50"
+                  className="px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50"
                   onClick={() => window.open(establishment.website, '_blank')}
                 >
                   🌐 Site


### PR DESCRIPTION
## Summary
- Adjusts the size of the phone and website buttons in the EstablishmentCards component
- Changes button padding and font size for a more compact and consistent appearance

## Changes

### UI Components
- **EstablishmentCards.tsx**: Modified button classes for phone and website buttons
  - Reduced padding from `px-3 py-2` to `px-2 py-1`
  - Changed font size from `text-sm` to `text-xs`
  - Removed `flex-1` to prevent buttons from stretching
  - Updated border radius class from `rounded-lg` to `rounded`

## Test plan
- [x] Verify that the phone and website buttons render with the updated smaller size
- [x] Check that buttons maintain hover background color effect
- [x] Confirm buttons do not stretch and align properly within the card layout

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3b884715-f82b-406a-a9a6-44fb9f01e0a4