### PR TITLE
Fix duplicate list entries by deduplicating data by title and address

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,24 +39,33 @@ export default function HomePage() {
           loadPilates()
         ]);
 
-        // Create unique identifiers and assign categories based on source file
-        const agenciasWithCategory = agenciasData.map((a, index) => ({ 
-          ...a, 
-          category: 'agencia' as const,
-          uniqueId: `agencia_${a.place_id}_${index}`
-        }));
-        
-        const restaurantesWithCategory = restaurantesData.map((r, index) => ({ 
-          ...r, 
-          category: 'restaurante' as const,
-          uniqueId: `restaurante_${r.place_id}_${index}`
-        }));
+        // Function to deduplicate array based on title and address
+        const deduplicateByNameAndAddress = (data: any[], category: string) => {
+          const seen = new Map();
+          const deduplicated = [];
+          
+          data.forEach((item, index) => {
+            const title = (item.title || '').toLowerCase().trim();
+            const address = (item.address || '').toLowerCase().trim();
+            const key = `${title}|${address}`;
+            
+            if (!seen.has(key) && title && address) {
+              seen.set(key, true);
+              deduplicated.push({
+                ...item,
+                category: category as const,
+                uniqueId: `${category}_${item.place_id}_${index}`
+              });
+            }
+          });
+          
+          return deduplicated;
+        };
 
-        const pilatesWithCategory = pilatesData.map((p, index) => ({ 
-          ...p, 
-          category: 'pilates' as const,
-          uniqueId: `pilates_${p.place_id}_${index}`
-        }));
+        // Deduplicate and create unique identifiers for each category
+        const agenciasWithCategory = deduplicateByNameAndAddress(agenciasData, 'agencia');
+        const restaurantesWithCategory = deduplicateByNameAndAddress(restaurantesData, 'restaurante');
+        const pilatesWithCategory = deduplicateByNameAndAddress(pilatesData, 'pilates');
 
         // Keep data separated by source
         setAgencias(agenciasWithCategory);


### PR DESCRIPTION
## Summary
- Fixes issue with duplicate entries in lists by deduplicating data based on title and address
- Introduces a reusable function to remove duplicates and assign unique identifiers
- Ensures each category (agencias, restaurantes, pilates) has unique and clean data

## Changes

### Data Processing
- Added `deduplicateByNameAndAddress` function to filter out duplicates by comparing lowercase trimmed title and address
- Replaced previous mapping logic with deduplication function for agencias, restaurantes, and pilates data
- Each item now receives a unique ID based on category, place_id, and index after deduplication

### Code Cleanup
- Removed redundant mapping code that did not handle duplicates

## Test plan
- Verify that lists for agencias, restaurantes, and pilates no longer contain duplicate entries
- Confirm uniqueId generation remains consistent and unique
- Test UI to ensure no regressions in data display or category assignment

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/95d6bd2d-1e97-4cd7-a2d7-6ac1e5efefa9